### PR TITLE
Expose more APIs to work with strands

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,4 +27,4 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/sgenoud/pantograph/blob/main/CLA/CLA.html' 
           branch: 'main'
-          allowlist: sgenoud,
+          allowlist: sgenoud

--- a/packages/pantograph/examples/box-dieline.js
+++ b/packages/pantograph/examples/box-dieline.js
@@ -1,0 +1,287 @@
+import { draw, cut, eraseStrand, exportSVG } from "../src/main";
+import { drawRect } from "../src/drawShape";
+import { Transformable } from "../src/models/exports";
+
+function drawFlap(
+  width,
+  height,
+  {
+    fillet = 1,
+    contraction = 1,
+    contractionMode = "rounded",
+    contractionLeft: contractionLeftInput,
+    contractionRight: contractionRightInput,
+    leftContractionMode,
+    rightContractionMode,
+  } = {}
+) {
+  const contractionLeft = contractionLeftInput ?? contraction;
+  const contractionRight = contractionRightInput ?? contraction;
+
+  const flapMaker = draw([-width / 2, 0]).hLine(width);
+
+  if (contractionRight) {
+    if ((rightContractionMode ?? contractionMode) === "rounded") {
+      flapMaker.tangentArc(-contractionRight, contractionRight, [-1, 0]);
+      flapMaker.vLine(height - contractionRight);
+    } else {
+      flapMaker.line(-contractionRight, height);
+    }
+  } else {
+    flapMaker.vLine(height);
+  }
+
+  flapMaker.customCorner(fillet);
+  flapMaker.hLine(-width + contractionLeft + contractionRight);
+  flapMaker.customCorner(fillet);
+
+  if (contractionLeft) {
+    if ((leftContractionMode ?? contractionMode) === "rounded") {
+      flapMaker.vLine(-height + contractionLeft);
+      flapMaker.tangentArcTo([-width / 2, 0]);
+    } else {
+      flapMaker.lineTo([-width / 2, 0]);
+    }
+  } else {
+    flapMaker.vLine(-height);
+  }
+
+  return flapMaker.close();
+}
+
+function topFlap(width, height, options) {
+  return drawFlap(width, height, options);
+}
+
+function bottomFlap(width, height, options) {
+  return drawFlap(width, height, options).mirror("x");
+}
+
+function leftFlap(
+  width,
+  height,
+  {
+    contractionTop,
+    contractionBottom,
+    topContractionMode,
+    bottomContractionMode,
+    ...options
+  }
+) {
+  return drawFlap(width, height, {
+    contractionLeft: contractionTop,
+    contractionRight: contractionBottom,
+    leftContractionMode: topContractionMode,
+    rightContractionMode: bottomContractionMode,
+    ...options,
+  }).rotate(90);
+}
+
+function rightFlap(width, height, options) {
+  return leftFlap(width, height, options).mirror("y");
+}
+
+const drawFlaps = {
+  right: rightFlap,
+  left: leftFlap,
+  top: topFlap,
+  bottom: bottomFlap,
+};
+
+// An experimental class that should make it easy to manager the different
+// parts of a dieline based on pantograph.
+class Dieline extends Transformable {
+  constructor(body, cuts = [], folds = []) {
+    super();
+    this.body = body;
+    this.cuts = [...cuts];
+    this.folds = [...folds];
+  }
+
+  addCut(cut) {
+    this.cuts.push(cut);
+    return this;
+  }
+
+  addFoldLine(fold) {
+    this.folds.push(fold);
+    return this;
+  }
+
+  fuseFold(fold) {
+    let otherBody = fold;
+
+    if (fold instanceof Dieline) {
+      otherBody = fold.body;
+      this.cuts.push(...fold.cuts);
+      this.folds.push(...fold.folds);
+    }
+
+    const commonLines = this.body.overlappingStrands(otherBody);
+    this.folds.push(...commonLines);
+
+    this.body = this.body.fuse(otherBody);
+
+    return this;
+  }
+
+  fuseBody(other) {
+    let otherBody = other;
+    if (other instanceof Dieline) {
+      otherBody = other.body;
+    }
+
+    this.body = this.body.fuse(otherBody);
+    return this;
+  }
+
+  cutShape(shape) {
+    this.body = cut(this.body, shape);
+    this.cuts = this.cuts.flatMap((cut) => eraseStrand(cut, shape, true));
+    this.folds = this.folds.flatMap((fold) => eraseStrand(fold, shape, true));
+    return this;
+  }
+
+  eraseFolds(shape) {
+    this.folds = this.folds.flatMap((fold) => eraseStrand(fold, shape, true));
+  }
+
+  transform(matrix) {
+    const newDieline = new Dieline(
+      this.body.transform(matrix),
+      this.cuts.map((cut) => cut.transform(matrix)),
+      this.folds.map((fold) => fold.transform(matrix))
+    );
+
+    return newDieline;
+  }
+
+  asSVG() {
+    const shapes = [];
+    if (this.body) {
+      shapes.push({ shape: this.body, color: "red" });
+    }
+    if (this.cuts) {
+      this.cuts.map((shape) => shapes.push({ shape, color: "red" }));
+    }
+
+    if (this.folds) {
+      this.folds.map((shape) => shapes.push({ shape, color: "green" }));
+    }
+
+    return exportSVG(shapes);
+  }
+}
+
+const drawBump = (width, height) => {
+  return draw([-width / 2, 0])
+    .line(height, -height)
+    .hLine(width - 2 * height)
+    .line(height, height);
+};
+
+// A helper class to create bumps for locking parts together without glue
+class FoldBump extends Transformable {
+  constructor(width, paperThickness = 0.1) {
+    super();
+
+    if (typeof width !== "number") {
+      this.cut = width.cut;
+      this.unfold = width.unfold;
+      this.bump = width.bump;
+      return;
+    }
+
+    const pen = drawBump(width, paperThickness * 2);
+
+    this.cut = pen.asStrand();
+    this.unfold = pen.close();
+
+    this.bump = drawBump(width - 2 * paperThickness, 3 * paperThickness)
+      .close()
+      .mirror("x");
+  }
+
+  transform(matrix) {
+    return new FoldBump({
+      cut: this.cut.transform(matrix),
+      unfold: this.unfold.transform(matrix),
+      bump: this.bump.transform(matrix),
+    });
+  }
+
+  makeCut(dieline) {
+    dieline.eraseFolds(this.unfold);
+    dieline.addCut(this.cut);
+  }
+
+  fuseBump(dieline) {
+    dieline.fuseBody(this.bump);
+  }
+}
+
+function basicTray(width, height, depth, { paperThickness = 0.1 } = {}) {
+  // The back and front sides are composed of two layers (inside and outside)
+  // that fold on top of each other. The inside layer will lock into some fold
+  // bumps
+  const backSide = new Dieline(
+    // The back side of the tray
+    drawRect(width - 2 * paperThickness, depth).translateY(depth / 2)
+  )
+    .fuseFold(
+      // the inner side of the back side of the tray (that folds on top of the
+      // flaps from the sides
+      drawFlaps
+        .top(width, depth, {
+          contraction: 3 * paperThickness,
+          fillet: 0,
+        })
+        .translateY(depth)
+    )
+    .translateY(height / 2);
+
+  // These correspond to the small bumps that lock the flaps without a need for glue
+  const bump = new FoldBump(5, paperThickness).translateY(height / 2);
+  const bumps = [
+    bump,
+    bump.translateX((-3 * width) / 8),
+    bump.translateX((3 * width) / 8),
+  ];
+  bumps.forEach((bump) => bump.translateY(2 * depth).fuseBump(backSide));
+
+  // The left and right sides are composed of a single rectangle for the side
+  // itself and two flaps that will be locked in by the two parts of the back
+  // / front
+  const innerFlapHeight = Math.min(2 * depth, width / 2 - 1);
+  const leftSide = new Dieline(drawRect(depth, height))
+    .fuseFold(
+      drawFlaps
+        .top(depth, innerFlapHeight, {
+          contractionLeft: 2 * paperThickness,
+        })
+        .translateY(height / 2)
+    )
+    .fuseFold(
+      drawFlaps
+        .bottom(depth, innerFlapHeight, {
+          contractionLeft: 2 * paperThickness,
+        })
+        .translateY(-height / 2)
+    )
+    .translateX(-width / 2 - depth / 2);
+
+  // We put it all together by fusing it with the bottom
+  const shape = new Dieline(drawRect(width, height))
+    .fuseFold(backSide)
+    .fuseFold(backSide.mirror("x")) // the front sidej
+    .fuseFold(leftSide)
+    .fuseFold(leftSide.mirror("y")); // the right side
+
+  // We need to cut in the bottom - and could not merge it before.
+  bumps.forEach((bump) => bump.makeCut(shape));
+  return shape;
+}
+
+export default function drawDieline() {
+  return basicTray(86, 63, 10, { paperThickness: 0.1 });
+}

--- a/packages/pantograph/index.html
+++ b/packages/pantograph/index.html
@@ -41,15 +41,17 @@
       <section class="container">
         <span role="button" onClick="showMandala()">Mandala</span>
         <span role="button" onClick="showStar()">Star</span>
+        <span role="button" onClick="showDieline()">Dieline</span>
       </section>
       <div id="app"></div>
       <script type="module">
         import { exportSVG } from "./src/main.ts";
         import mandala from "./examples/mandala.js";
         import drawStar from "./examples/star.js";
+        import drawDieline from "./examples/box-dieline.js";
 
-        const updatePage = (drawing) => {
-          const svg = exportSVG(drawing, 1);
+        const updatePage = (drawing, alreadyExported = false) => {
+          const svg = alreadyExported ? drawing : exportSVG(drawing, 1);
           const canvas = document.getElementById("app");
 
           canvas.innerHTML = svg;
@@ -63,7 +65,11 @@
           updatePage(drawStar(7));
         };
 
-        showStar();
+        window.showDieline = () => {
+          updatePage(drawDieline().asSVG(), true);
+        };
+
+        showDieline();
       </script>
     </main>
   </body>

--- a/packages/pantograph/package.json
+++ b/packages/pantograph/package.json
@@ -17,6 +17,10 @@
     "./models": {
       "import": "./dist/pantograph/models.js",
       "require": "./dist/pantograph/models.cjs"
+    },
+    "./drawShape": {
+      "import": "./dist/pantograph/drawShape.js",
+      "require": "./dist/pantograph/drawShape.cjs"
     }
   },
   "scripts": {

--- a/packages/pantograph/src/algorithms/boolean/loopBooleans.ts
+++ b/packages/pantograph/src/algorithms/boolean/loopBooleans.ts
@@ -8,6 +8,7 @@ import { Loop } from "../../models/Loop";
 import { findIntersectionsAndOverlaps } from "../intersections";
 import removeDuplicatePoints from "../../utils/removeDuplicatePoints";
 import { stitchSegments } from "../stitchSegments";
+import { strandsBetweenIntersections } from "./strandsBetweenIntersections";
 
 const rotateToStartAt = (segments: Segment[], point: Vector) => {
   const startIndex = segments.findIndex((segment: Segment) => {
@@ -53,46 +54,6 @@ const rotateToStartAtSegment = (segments: Segment[], segment: Segment) => {
 
   return end.concat(start);
 };
-
-function* strandsBetweenIntersections(
-  segments: Segment[],
-  allIntersections: Vector[],
-  allCommonSegments: Segment[]
-): Generator<Strand> {
-  const endsAtIntersection = (segment: Segment) => {
-    return allIntersections.some((intersection) => {
-      return sameVector(intersection, segment.lastPoint);
-    });
-  };
-
-  const isCommonSegment = (commonSegment: Segment) => {
-    return allCommonSegments.some((segment) => {
-      return commonSegment.isSame(segment);
-    });
-  };
-
-  let currentCurves: Segment[] = [];
-  for (const segment of segments) {
-    // We ignore the checks at strand creation as these strands are part of
-    // a loop and can be trusted to be valid
-    if (endsAtIntersection(segment)) {
-      currentCurves.push(segment);
-      yield new Strand(currentCurves, { ignoreChecks: true });
-      currentCurves = [];
-    } else if (isCommonSegment(segment)) {
-      if (currentCurves.length) {
-        yield new Strand(currentCurves, { ignoreChecks: true });
-        currentCurves = [];
-      }
-      yield new Strand([segment], { ignoreChecks: true });
-    } else {
-      currentCurves.push(segment);
-    }
-  }
-  if (currentCurves.length) {
-    yield new Strand(currentCurves, { ignoreChecks: true });
-  }
-}
 
 type IntersectionStrand = [Strand, Strand | "same"];
 

--- a/packages/pantograph/src/algorithms/boolean/strandBoolean.ts
+++ b/packages/pantograph/src/algorithms/boolean/strandBoolean.ts
@@ -1,0 +1,131 @@
+import { Vector } from "../../definitions";
+import { Segment } from "../../models/segments/Segment";
+import { Loop } from "../../models/Loop";
+import { Strand } from "../../models/Strand";
+import { findIntersectionsAndOverlaps } from "../intersections";
+import removeDuplicatePoints from "../../utils/removeDuplicatePoints";
+import zip from "../../utils/zip";
+import { strandsBetweenIntersections } from "./strandsBetweenIntersections";
+import { Figure } from "../../main";
+
+function strandLoopSections(
+  loop: Loop,
+  strand: Strand,
+  precision = 1e-9
+): Strand[] {
+  let allIntersections: Vector[] = [];
+  const allCommonSegments: Segment[] = [];
+
+  const splitPoints: Vector[][] = new Array(strand.segments.length)
+    .fill(0)
+    .map(() => []);
+
+  strand.segments.forEach((strandSegment, strandIndex) => {
+    loop.segments.forEach((loopSegment) => {
+      const { intersections, overlaps } = findIntersectionsAndOverlaps(
+        strandSegment,
+        loopSegment,
+        precision
+      );
+
+      allIntersections.push(...intersections);
+      splitPoints[strandIndex].push(...intersections);
+
+      allCommonSegments.push(...overlaps);
+      const commonSegmentsPoints = overlaps.flatMap((s) => [
+        s.firstPoint,
+        s.lastPoint,
+      ]);
+      allIntersections.push(...commonSegmentsPoints);
+      splitPoints[strandIndex].push(...commonSegmentsPoints);
+    });
+  });
+
+  allIntersections = removeDuplicatePoints(allIntersections, precision);
+
+  const strandSegments = zip([strand.segments, splitPoints] as [
+    Segment[],
+    Vector[][]
+  ]).flatMap(([segment, intersections]: [Segment, Vector[]]): Segment[] => {
+    if (!intersections.length) return [segment];
+    return segment.splitAt(intersections);
+  });
+
+  return Array.from(
+    strandsBetweenIntersections(
+      strandSegments,
+      allIntersections,
+      allCommonSegments
+    )
+  );
+}
+
+export function eraseStrandWithinLoop(
+  strand: Strand,
+  loop: Loop,
+  eraseOnBorder = false
+) {
+  const strands = strandLoopSections(loop, strand);
+
+  // We keep only the strands that are outside the loop
+  return strands.filter((strand) => {
+    const strandCenter = strand.segments[0].midPoint;
+    if (loop.onStroke(strandCenter)) return !eraseOnBorder;
+
+    return !loop.contains(strandCenter);
+  });
+}
+
+export function eraseStrandOutsideLoop(
+  strand: Strand,
+  loop: Loop,
+  eraseOnBorder = false
+) {
+  const strands = strandLoopSections(loop, strand);
+
+  // We keep only the strands that are outside the loop
+  return strands.filter((strand) => {
+    const strandCenter = strand.segments[0].midPoint;
+    if (loop.onStroke(strandCenter)) return !eraseOnBorder;
+
+    return loop.contains(strandCenter);
+  });
+}
+
+export function eraseStrandWithinFigure(
+  strand: Strand,
+  figure: Figure,
+  eraseOnBorder = false
+) {
+  const outsideStrands = eraseStrandWithinLoop(
+    strand,
+    figure.contour,
+    eraseOnBorder
+  );
+
+  const inLoopStrand = figure.holes.flatMap((hole: Loop) =>
+    eraseStrandOutsideLoop(strand, hole, eraseOnBorder)
+  );
+
+  return [...outsideStrands, ...inLoopStrand];
+}
+
+export function eraseStrandOutsideFigure(
+  strand: Strand,
+  figure: Figure,
+  eraseOnBorder = false
+) {
+  let insideStrands = eraseStrandOutsideLoop(
+    strand,
+    figure.contour,
+    eraseOnBorder
+  );
+
+  figure.holes.forEach((hole: Loop) => {
+    insideStrands = insideStrands.flatMap((strand) =>
+      eraseStrandWithinLoop(strand, hole, eraseOnBorder)
+    );
+  });
+
+  return insideStrands;
+}

--- a/packages/pantograph/src/algorithms/boolean/strandsBetweenIntersections.ts
+++ b/packages/pantograph/src/algorithms/boolean/strandsBetweenIntersections.ts
@@ -1,0 +1,44 @@
+import { Vector } from "../../definitions";
+import { Segment } from "../../models/segments/Segment";
+import { Strand } from "../../models/Strand";
+import { sameVector } from "../../vectorOperations";
+
+export function* strandsBetweenIntersections(
+  segments: Segment[],
+  allIntersections: Vector[],
+  allCommonSegments: Segment[]
+): Generator<Strand> {
+  const endsAtIntersection = (segment: Segment) => {
+    return allIntersections.some((intersection) => {
+      return sameVector(intersection, segment.lastPoint);
+    });
+  };
+
+  const isCommonSegment = (commonSegment: Segment) => {
+    return allCommonSegments.some((segment) => {
+      return commonSegment.isSame(segment);
+    });
+  };
+
+  let currentCurves: Segment[] = [];
+  for (const segment of segments) {
+    // We ignore the checks at strand creation as these strands are part of
+    // a loop and can be trusted to be valid
+    if (endsAtIntersection(segment)) {
+      currentCurves.push(segment);
+      yield new Strand(currentCurves, { ignoreChecks: true });
+      currentCurves = [];
+    } else if (isCommonSegment(segment)) {
+      if (currentCurves.length) {
+        yield new Strand(currentCurves, { ignoreChecks: true });
+        currentCurves = [];
+      }
+      yield new Strand([segment], { ignoreChecks: true });
+    } else {
+      currentCurves.push(segment);
+    }
+  }
+  if (currentCurves.length) {
+    yield new Strand(currentCurves, { ignoreChecks: true });
+  }
+}

--- a/packages/pantograph/src/booleanOperations.ts
+++ b/packages/pantograph/src/booleanOperations.ts
@@ -3,10 +3,17 @@ import {
   fuseFiguresLists,
   intersectFiguresLists,
 } from "./algorithms/boolean/figureBooleans";
+import { Strand } from "./models/Strand";
 import { Diagram } from "./models/Diagram";
 import { Figure } from "./models/Figure";
 import { Loop } from "./models/Loop";
 import { listOfFigures } from "./utils/listOfFigures";
+import {
+  eraseStrandOutsideFigure,
+  eraseStrandOutsideLoop,
+  eraseStrandWithinFigure,
+  eraseStrandWithinLoop,
+} from "./algorithms/boolean/strandBoolean";
 
 export function fuse(
   first: Diagram | Figure | Loop,
@@ -40,4 +47,50 @@ export function intersect(
   return new Diagram(
     intersectFiguresLists(listOfFigures(first), listOfFigures(second))
   );
+}
+
+export function eraseStrand(
+  strand: Strand,
+  diagram: Diagram | Figure | Loop,
+  eraseOnBorder = true
+): Strand[] {
+  if (diagram instanceof Loop) {
+    return eraseStrandWithinLoop(strand, diagram, eraseOnBorder);
+  }
+
+  if (diagram instanceof Figure) {
+    return eraseStrandWithinFigure(strand, diagram, eraseOnBorder);
+  }
+
+  let outStrands: Strand[] = [strand];
+  diagram.figures.forEach((figure: Figure) => {
+    outStrands = outStrands.flatMap((strand: Strand) => {
+      return eraseStrandWithinFigure(strand, figure, eraseOnBorder);
+    });
+  });
+
+  return outStrands;
+}
+
+export function confineStrand(
+  strand: Strand,
+  diagram: Diagram | Figure | Loop,
+  eraseOnBorder = false
+): Strand[] {
+  if (diagram instanceof Loop) {
+    return eraseStrandOutsideLoop(strand, diagram, eraseOnBorder);
+  }
+
+  if (diagram instanceof Figure) {
+    return eraseStrandOutsideFigure(strand, diagram, eraseOnBorder);
+  }
+
+  let outStrands: Strand[] = [strand];
+  diagram.figures.forEach((figure: Figure) => {
+    outStrands = outStrands.flatMap((strand: Strand) => {
+      return eraseStrandOutsideFigure(strand, figure, eraseOnBorder);
+    });
+  });
+
+  return outStrands;
 }

--- a/packages/pantograph/src/draw.ts
+++ b/packages/pantograph/src/draw.ts
@@ -190,28 +190,34 @@ export class DrawingPen {
     return this.bulgeArc(distance, 0, bulge);
   }
 
-  tangentArcTo(end: Vector): this {
+  tangentArcTo(end: Vector, tangentAtStart?: Vector): this {
     const previousCurve = this.pendingSegments.at(-1);
 
     if (!previousCurve)
       throw new Error("You need a previous curve to sketch a tangent arc");
 
     this.saveSegment(
-      tangentArc(this.pointer, end, previousCurve.tangentAtLastPoint)
+      tangentArc(
+        this.pointer,
+        end,
+        tangentAtStart ?? previousCurve.tangentAtLastPoint
+      )
     );
 
     this.pointer = end;
     return this;
   }
 
-  tangentArc(xDist: number, yDist: number): this {
+  tangentArc(xDist: number, yDist: number, tangentAtStart?: Vector): this {
     const [x0, y0] = this.pointer;
-    return this.tangentArcTo([xDist + x0, yDist + y0]);
+    return this.tangentArcTo([xDist + x0, yDist + y0], tangentAtStart);
   }
 
   customCorner(radius: number, mode: "fillet" | "chamfer" = "fillet") {
     if (!this.pendingSegments.length)
       throw new Error("You need a segment defined to fillet the angle");
+
+    if (!radius) return this;
 
     this._nextCorner = { mode, radius };
     return this;

--- a/packages/pantograph/src/draw.ts
+++ b/packages/pantograph/src/draw.ts
@@ -1,5 +1,6 @@
 import { chamferSegments, filletSegments } from "./algorithms/filletSegments";
 import { Vector } from "./definitions";
+import { Strand } from "./models/Strand";
 import { Diagram } from "./models/Diagram";
 import { Figure } from "./models/Figure";
 import { Loop } from "./models/Loop";
@@ -22,7 +23,7 @@ function loopySegmentsToDiagram(segments: Segment[]) {
   // Here we will need to do our best to fix cases where the drawing is
   // broken in some way (i.e. self-intersecting loops)
 
-  return new Diagram([new Figure(new Loop(segments))]);
+  return new Diagram([new Figure(new Loop([...segments]))]);
 }
 
 export class DrawingPen {
@@ -279,6 +280,10 @@ export class DrawingPen {
       ...this.pendingSegments,
       ...mirroredSegments,
     ]);
+  }
+
+  asStrand(): Strand {
+    return new Strand([...this.pendingSegments]);
   }
 }
 

--- a/packages/pantograph/src/drawShape/drawRect.ts
+++ b/packages/pantograph/src/drawShape/drawRect.ts
@@ -1,7 +1,7 @@
 import { draw } from "../draw";
 import type { Diagram } from "../models/Diagram";
 
-export function drawRect(width: number, height: number, r: number): Diagram {
+export function drawRect(width: number, height: number, r?: number): Diagram {
   // This will be changed once we support arc of ellipses
   const { rx: inputRx = 0, ry: inputRy = 0 } = { ry: r, rx: r };
 

--- a/packages/pantograph/src/main.ts
+++ b/packages/pantograph/src/main.ts
@@ -30,7 +30,18 @@ export type {
 } from "./models/exports";
 
 export { draw } from "./draw";
-export { fuse, fuseAll, cut, intersect, offset } from "./operations";
+export {
+  // Surface booleans
+  fuseAll,
+  fuse,
+  cut,
+  intersect,
+  // Strand booleans
+  eraseStrand,
+  confineStrand,
+  // Offset
+  offset,
+} from "./operations";
 
 export { exportSVG, svgBody } from "./export/svg/exportSVG";
 

--- a/packages/pantograph/src/models/Diagram.ts
+++ b/packages/pantograph/src/models/Diagram.ts
@@ -10,6 +10,8 @@ import {
 } from "../algorithms/boolean/figureBooleans";
 import { combineDifferentValues } from "../utils/allCombinations";
 import { Transformable } from "./utils/Transformable";
+import { Strand } from "./Strand";
+import type { Stroke } from "./Stroke";
 
 export class Diagram extends Transformable<Diagram> {
   figures: Figure[];
@@ -54,6 +56,18 @@ export class Diagram extends Transformable<Diagram> {
     return this.figures.some((figure) =>
       other.figures.some((otherFigure) => figure.intersects(otherFigure))
     );
+  }
+
+  overlappingStrands(other: Diagram | Figure | Stroke): Strand[] {
+    return this.figures.flatMap((figure) => {
+      if (!(other instanceof Diagram)) {
+        return figure.overlappingStrands(other);
+      }
+
+      return other.figures.flatMap((otherFigure) =>
+        figure.overlappingStrands(otherFigure)
+      );
+    });
   }
 
   fuse(other: Diagram): Diagram {

--- a/packages/pantograph/src/models/Figure.ts
+++ b/packages/pantograph/src/models/Figure.ts
@@ -2,9 +2,12 @@ import { Vector } from "../definitions";
 import { TransformationMatrix } from "./TransformationMatrix";
 import type { BoundingBox } from "./BoundingBox";
 import { Loop } from "./Loop";
+import { Strand } from "./Strand";
+import type { Stroke } from "./Stroke";
 import { combineDifferentValues } from "../utils/allCombinations";
 import { Transformable } from "./utils/Transformable";
-import { exportJSON } from "../main";
+import { exportJSON } from "../export/json/exportJSON";
+import { stitchSegments } from "../algorithms/stitchSegments";
 
 export class Figure extends Transformable<Figure> {
   readonly contour: Loop;
@@ -58,6 +61,19 @@ export class Figure extends Transformable<Figure> {
     return this.allLoops.some((loop) =>
       other.allLoops.some((otherLoop) => loop.intersects(otherLoop))
     );
+  }
+
+  overlappingStrands(other: Figure | Stroke): Strand[] {
+    const otherStrokes = other instanceof Figure ? other.allLoops : [other];
+    const overlappingSegments = this.allLoops.flatMap((loop) => {
+      return otherStrokes.flatMap((otherLoop) => {
+        return loop.overlappingSegments(otherLoop);
+      });
+    });
+
+    return stitchSegments(overlappingSegments).map((segments) => {
+      return new Strand(segments);
+    });
   }
 }
 

--- a/packages/pantograph/src/models/Stroke.ts
+++ b/packages/pantograph/src/models/Stroke.ts
@@ -20,6 +20,9 @@ export abstract class AbstractStroke<
   get repr(): string {
     return this.segments.map((segment) => segment.repr).join("\n") + "\n";
   }
+  get info(): string {
+    return this.repr;
+  }
   constructor(segments: Segment[], { ignoreChecks = false } = {}) {
     super();
     if (!ignoreChecks) checkValidStroke(segments);
@@ -116,8 +119,13 @@ export function checkSelfIntersections(
             return;
         }
       }
+
       throw new Error(
-        `${type} segments must not intersect, but segments ${segment.repr} and ${otherSegment.repr} do`
+        `${type} segments must not intersect, but segments ${
+          segment.info
+        } and ${otherSegment.info} do at ${JSON.stringify(
+          intersections.intersections
+        )}`
       );
     }
   );
@@ -131,7 +139,7 @@ export function checkValidStroke(segments: Segment[], type = "Stroke"): void {
     ([segment, nextSegment]) => {
       if (!sameVector(segment.lastPoint, nextSegment.firstPoint))
         throw new Error(
-          `${type} segments must be connected, but ${segment.repr} and ${nextSegment.repr} are not`
+          `${type} segments must be connected, but ${segment.info} and ${nextSegment.info} are not`
         );
     }
   );

--- a/packages/pantograph/src/models/Stroke.ts
+++ b/packages/pantograph/src/models/Stroke.ts
@@ -55,6 +55,15 @@ export abstract class AbstractStroke<
     );
   }
 
+  overlappingSegments(other: Stroke): Segment[] {
+    return this.segments.flatMap((segment) => {
+      return other.segments.flatMap((otherSegment) => {
+        if (!segment.boundingBox.overlaps(otherSegment.boundingBox)) return [];
+        return findIntersectionsAndOverlaps(segment, otherSegment).overlaps;
+      });
+    });
+  }
+
   private _boundingBox: BoundingBox | null = null;
   get boundingBox(): BoundingBox {
     if (this._boundingBox === null) {

--- a/packages/pantograph/src/models/exports.ts
+++ b/packages/pantograph/src/models/exports.ts
@@ -10,3 +10,5 @@ export { TransformationMatrix } from "./TransformationMatrix";
 export { Line } from "./segments/Line";
 export { Arc } from "./segments/Arc";
 export type { Segment } from "./segments/Segment";
+
+export { Transformable } from "./utils/Transformable";

--- a/packages/pantograph/src/models/segments/AbstractSegment.ts
+++ b/packages/pantograph/src/models/segments/AbstractSegment.ts
@@ -22,6 +22,9 @@ export abstract class AbstractSegment<
       this.lastPoint
     )}`;
   }
+  get info() {
+    return this.repr;
+  }
 
   abstract get midPoint(): Vector;
 

--- a/packages/pantograph/src/models/segments/Arc.ts
+++ b/packages/pantograph/src/models/segments/Arc.ts
@@ -59,6 +59,12 @@ export class Arc extends AbstractSegment<Arc> {
     }
   }
 
+  get info() {
+    return `ARC(${reprVector(this.firstPoint)}, ${reprVector(
+      this.lastPoint
+    )}, ${reprVector(this.center)}, ${this.clockwise ? "CW" : "CCW"})`;
+  }
+
   isValidParameter(t: number): boolean {
     return 1 - t >= -this.precision && t >= -this.precision;
   }

--- a/packages/pantograph/src/models/segments/Segment.ts
+++ b/packages/pantograph/src/models/segments/Segment.ts
@@ -24,6 +24,9 @@ export abstract class AbstractSegment<
       this.lastPoint
     )}`;
   }
+  get info() {
+    return this.repr;
+  }
 
   abstract get midPoint(): Vector;
 

--- a/packages/pantograph/src/utils/angularDistance.ts
+++ b/packages/pantograph/src/utils/angularDistance.ts
@@ -1,7 +1,8 @@
 export function angularDistance(
   angle1: number,
   angle2: number,
-  clockwise: boolean
+  clockwise: boolean,
+  precision = 1e-9
 ) {
   let relDistance = angle2 - angle1;
 
@@ -12,5 +13,10 @@ export function angularDistance(
   if (relDistance < 0) {
     relDistance += 2 * Math.PI;
   }
+
+  if (relDistance > 2 * Math.PI - precision) {
+    return 0;
+  }
+
   return relDistance;
 }

--- a/packages/pantograph/src/utils/unitAngle.ts
+++ b/packages/pantograph/src/utils/unitAngle.ts
@@ -1,10 +1,15 @@
 // makes sure the angle is in one unit circle
-export function unitAngle(angle: number) {
+export function unitAngle(angle: number, precision = 1e-9) {
   if (angle < 0) {
     return angle + 2 * Math.PI;
   }
   if (angle >= 2 * Math.PI) {
     return angle % (2 * Math.PI);
   }
+
+  if (angle > 2 * Math.PI - precision) {
+    return 0;
+  }
+
   return angle;
 }

--- a/packages/pantograph/test/algorithms/booleans/__snapshots__/strandBooleans.spec.ts.snap
+++ b/packages/pantograph/test/algorithms/booleans/__snapshots__/strandBooleans.spec.ts.snap
@@ -1,0 +1,343 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`eraseStrandOutsideLoop > should erase the parts of a strand within a loop 1`] = `
+[
+  Strand {
+    "_boundingBox": null,
+    "segments": [
+      Line {
+        "_V": [
+          1,
+          0.5,
+        ],
+        "_boundingBox": null,
+        "firstPoint": [
+          0,
+          -1.5,
+        ],
+        "lastPoint": [
+          1,
+          -1,
+        ],
+        "precision": 1e-9,
+        "segmentType": "LINE",
+      },
+      Line {
+        "_V": [
+          -0.5,
+          2,
+        ],
+        "_boundingBox": null,
+        "firstPoint": [
+          1,
+          -1,
+        ],
+        "lastPoint": [
+          0.5,
+          1,
+        ],
+        "precision": 1e-9,
+        "segmentType": "LINE",
+      },
+      Line {
+        "_V": null,
+        "_boundingBox": null,
+        "firstPoint": [
+          0.5,
+          1,
+        ],
+        "lastPoint": [
+          1.125,
+          1.5,
+        ],
+        "precision": 1e-9,
+        "segmentType": "LINE",
+      },
+    ],
+    "strokeType": "STRAND",
+  },
+]
+`;
+
+exports[`eraseStrandOutsideLoop > should erase the parts of on the border when configured that way 1`] = `
+[
+  Strand {
+    "_boundingBox": null,
+    "segments": [
+      Line {
+        "_V": [
+          1.5,
+          2.5,
+        ],
+        "_boundingBox": null,
+        "firstPoint": [
+          -1,
+          -1.5,
+        ],
+        "lastPoint": [
+          0.5,
+          1,
+        ],
+        "precision": 1e-9,
+        "segmentType": "LINE",
+      },
+      Line {
+        "_V": null,
+        "_boundingBox": null,
+        "firstPoint": [
+          0.5,
+          1,
+        ],
+        "lastPoint": [
+          1.125,
+          1.5,
+        ],
+        "precision": 1e-9,
+        "segmentType": "LINE",
+      },
+    ],
+    "strokeType": "STRAND",
+  },
+]
+`;
+
+exports[`eraseStrandOutsideLoop > should not erase the parts of on the border when configured that way 1`] = `
+[
+  Strand {
+    "_boundingBox": null,
+    "segments": [
+      Line {
+        "_V": [
+          -2,
+          0,
+        ],
+        "_boundingBox": null,
+        "firstPoint": [
+          1,
+          -1.5,
+        ],
+        "lastPoint": [
+          -1,
+          -1.5,
+        ],
+        "precision": 1e-9,
+        "segmentType": "LINE",
+      },
+    ],
+    "strokeType": "STRAND",
+  },
+  Strand {
+    "_boundingBox": null,
+    "segments": [
+      Line {
+        "_V": [
+          1.5,
+          2.5,
+        ],
+        "_boundingBox": null,
+        "firstPoint": [
+          -1,
+          -1.5,
+        ],
+        "lastPoint": [
+          0.5,
+          1,
+        ],
+        "precision": 1e-9,
+        "segmentType": "LINE",
+      },
+      Line {
+        "_V": null,
+        "_boundingBox": null,
+        "firstPoint": [
+          0.5,
+          1,
+        ],
+        "lastPoint": [
+          1.125,
+          1.5,
+        ],
+        "precision": 1e-9,
+        "segmentType": "LINE",
+      },
+    ],
+    "strokeType": "STRAND",
+  },
+]
+`;
+
+exports[`eraseStrandWithinLoop > should erase the parts of a strand within a loop 1`] = `
+[
+  Strand {
+    "_boundingBox": null,
+    "segments": [
+      Line {
+        "_V": [
+          3,
+          1.5,
+        ],
+        "_boundingBox": null,
+        "firstPoint": [
+          -3,
+          -3,
+        ],
+        "lastPoint": [
+          0,
+          -1.5,
+        ],
+        "precision": 1e-9,
+        "segmentType": "LINE",
+      },
+    ],
+    "strokeType": "STRAND",
+  },
+  Strand {
+    "_boundingBox": null,
+    "segments": [
+      Line {
+        "_V": [
+          1.875,
+          1.5,
+        ],
+        "_boundingBox": null,
+        "firstPoint": [
+          1.125,
+          1.5,
+        ],
+        "lastPoint": [
+          3,
+          3,
+        ],
+        "precision": 1e-9,
+        "segmentType": "LINE",
+      },
+    ],
+    "strokeType": "STRAND",
+  },
+]
+`;
+
+exports[`eraseStrandWithinLoop > should erase the parts of on the border when configured that way 1`] = `
+[
+  Strand {
+    "_boundingBox": null,
+    "segments": [
+      Line {
+        "_V": [
+          4,
+          1.5,
+        ],
+        "_boundingBox": null,
+        "firstPoint": [
+          -3,
+          -3,
+        ],
+        "lastPoint": [
+          1,
+          -1.5,
+        ],
+        "precision": 1e-9,
+        "segmentType": "LINE",
+      },
+    ],
+    "strokeType": "STRAND",
+  },
+  Strand {
+    "_boundingBox": null,
+    "segments": [
+      Line {
+        "_V": [
+          1.875,
+          1.5,
+        ],
+        "_boundingBox": null,
+        "firstPoint": [
+          1.125,
+          1.5,
+        ],
+        "lastPoint": [
+          3,
+          3,
+        ],
+        "precision": 1e-9,
+        "segmentType": "LINE",
+      },
+    ],
+    "strokeType": "STRAND",
+  },
+]
+`;
+
+exports[`eraseStrandWithinLoop > should not erase the parts of on the border when configured that way 1`] = `
+[
+  Strand {
+    "_boundingBox": null,
+    "segments": [
+      Line {
+        "_V": [
+          4,
+          1.5,
+        ],
+        "_boundingBox": null,
+        "firstPoint": [
+          -3,
+          -3,
+        ],
+        "lastPoint": [
+          1,
+          -1.5,
+        ],
+        "precision": 1e-9,
+        "segmentType": "LINE",
+      },
+    ],
+    "strokeType": "STRAND",
+  },
+  Strand {
+    "_boundingBox": null,
+    "segments": [
+      Line {
+        "_V": [
+          -2,
+          0,
+        ],
+        "_boundingBox": null,
+        "firstPoint": [
+          1,
+          -1.5,
+        ],
+        "lastPoint": [
+          -1,
+          -1.5,
+        ],
+        "precision": 1e-9,
+        "segmentType": "LINE",
+      },
+    ],
+    "strokeType": "STRAND",
+  },
+  Strand {
+    "_boundingBox": null,
+    "segments": [
+      Line {
+        "_V": [
+          1.875,
+          1.5,
+        ],
+        "_boundingBox": null,
+        "firstPoint": [
+          1.125,
+          1.5,
+        ],
+        "lastPoint": [
+          3,
+          3,
+        ],
+        "precision": 1e-9,
+        "segmentType": "LINE",
+      },
+    ],
+    "strokeType": "STRAND",
+  },
+]
+`;

--- a/packages/pantograph/test/algorithms/booleans/brokenModels.spec.ts
+++ b/packages/pantograph/test/algorithms/booleans/brokenModels.spec.ts
@@ -6,7 +6,7 @@ import { cut } from "../../../src/booleanOperations";
 import fixture from "./fixture1.json";
 
 describe("tests that correspond to bugs found in real models", () => {
-  it.only("should cut the model in fixture 1", () => {
+  it("should cut the model in fixture 1", () => {
     const [a, b] = fixture.map(importJSON);
     const cutted = cut(a, b);
     expect(cutted).toMatchSnapshot();

--- a/packages/pantograph/test/algorithms/booleans/strandBooleans.spec.ts
+++ b/packages/pantograph/test/algorithms/booleans/strandBooleans.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+
+import { draw } from "../../../src/draw";
+import { drawRect } from "../../../src/drawShape";
+
+import { debugImg } from "../../debug";
+
+import {
+  eraseStrandWithinLoop,
+  eraseStrandOutsideLoop,
+} from "../../../src/algorithms/boolean/strandBoolean";
+
+// Note: all the tests are checked visually by using `debugImg`. Please do so
+// as well when you add new tests or have some failures.
+
+describe("eraseStrandWithinLoop", () => {
+  it("should erase the parts of a strand within a loop", () => {
+    const r = drawRect(5, 3).figures[0].contour;
+    const s = draw([-3, -3])
+      .lineTo([1, -1])
+      .lineTo([0.5, 1])
+      .lineTo([3, 3])
+      .asStrand();
+
+    expect(eraseStrandWithinLoop(s, r)).toMatchSnapshot();
+  });
+
+  it("should not erase the parts of on the border when configured that way", () => {
+    const r = drawRect(5, 3).figures[0].contour;
+    const s = draw([-3, -3])
+      .lineTo([1, -1.5])
+      .lineTo([-1, -1.5])
+      .lineTo([0.5, 1])
+      .lineTo([3, 3])
+      .asStrand();
+
+    expect(eraseStrandWithinLoop(s, r)).toMatchSnapshot();
+  });
+
+  it("should erase the parts of on the border when configured that way", () => {
+    const r = drawRect(5, 3).figures[0].contour;
+    const s = draw([-3, -3])
+      .lineTo([1, -1.5])
+      .lineTo([-1, -1.5])
+      .lineTo([0.5, 1])
+      .lineTo([3, 3])
+      .asStrand();
+
+    expect(eraseStrandWithinLoop(s, r, true)).toMatchSnapshot();
+  });
+});
+
+describe("eraseStrandOutsideLoop", () => {
+  it("should erase the parts of a strand within a loop", () => {
+    const r = drawRect(5, 3).figures[0].contour;
+    const s = draw([-3, -3])
+      .lineTo([1, -1])
+      .lineTo([0.5, 1])
+      .lineTo([3, 3])
+      .asStrand();
+
+    expect(eraseStrandOutsideLoop(s, r)).toMatchSnapshot();
+  });
+
+  it("should not erase the parts of on the border when configured that way", () => {
+    const r = drawRect(5, 3).figures[0].contour;
+    const s = draw([-3, -3])
+      .lineTo([1, -1.5])
+      .lineTo([-1, -1.5])
+      .lineTo([0.5, 1])
+      .lineTo([3, 3])
+      .asStrand();
+
+    expect(eraseStrandOutsideLoop(s, r)).toMatchSnapshot();
+  });
+
+  it("should erase the parts of on the border when configured that way", () => {
+    const r = drawRect(5, 3).figures[0].contour;
+    const s = draw([-3, -3])
+      .lineTo([1, -1.5])
+      .lineTo([-1, -1.5])
+      .lineTo([0.5, 1])
+      .lineTo([3, 3])
+      .asStrand();
+
+    debugImg([r, s]);
+    debugImg(eraseStrandOutsideLoop(s, r, true), "erased");
+
+    expect(eraseStrandOutsideLoop(s, r, true)).toMatchSnapshot();
+  });
+});

--- a/packages/pantograph/test/algorithms/intersections/rayIntersections.spec.ts
+++ b/packages/pantograph/test/algorithms/intersections/rayIntersections.spec.ts
@@ -50,7 +50,7 @@ describe("rayIntersectionsCount", () => {
       ).toBe(1);
     });
 
-    it.only("should return 1 for this other arc that was buggy", () => {
+    it("should return 1 for this other arc that was buggy", () => {
       const arc = new Arc(
         [38.52710211020566, 42.26221778725147],
         [34.48816871800838, 46.554145764976006],

--- a/packages/pantograph/vite.config.ts
+++ b/packages/pantograph/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       entry: {
         pantograph: resolve(__dirname, "src/main.ts"),
         "pantograph/models": resolve(__dirname, "src/models/exports.ts"),
+        "pantograph/drawShape": resolve(__dirname, "src/drawShape/index.ts"),
       },
       name: "Pantograph",
     },


### PR DESCRIPTION
While I am doing more experiments to tests the limits of the exposed API I have improved the whole API, especially relating to strands.

The `draw` pen object can now return a strand with `asStrand`.

There are two new boolean operations, that work with strands: `eraseStrand` and `confineStrand`. They do boolean operations on the strand by remove parts of it - either the parts that are within a diagram (erase) or outside (confine). I am open to new terminologies!

There is also new methods on most objects to figure out parts of their stroke that is common - these are returned as an array of strands (or segments).

All of this was at the service of a new example, playing with dielines. This is some improvement on designs I made for [deckinabox](https://deckinabox.sgenoud.com/folded). 

![svgexport-1](https://user-images.githubusercontent.com/263325/234230018-b7516e99-b9ae-4bc7-91d3-db73c8d033bf.svg)
